### PR TITLE
Update lambda runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-03-05
+- update lambda runtime to java8.al2
+
 ## [0.4.0] - 2022-01-10
 - latest log4j
 - use published aws-athena-federation-sdk from maven central

--- a/athena-udfs-textanalytics/athena-udfs-textanalytics.yaml
+++ b/athena-udfs-textanalytics/athena-udfs-textanalytics.yaml
@@ -1,9 +1,9 @@
 Transform: 'AWS::Serverless-2016-10-31'
-Description: Sample Amazon Athena UDFs for text translation and analytics using Amazon Comprehend and Amazon Translate (v0.4.0)
+Description: Sample Amazon Athena UDFs for text translation and analytics using Amazon Comprehend and Amazon Translate (v0.4.1)
 Metadata:
   'AWS::ServerlessRepo::Application':
     Name: TextAnalyticsUDFHandler
-    SemanticVersion: 0.4.0
+    SemanticVersion: 0.4.1
     Description: 'This Athena UDF provides (i) text translation using Amazon Translate, (ii) text analytics including detection of language, sentiment, key phrases, entities and PII using Amazon Comprehend, and (iii) redaction of detected entities and PII.'
     Author: 'Bob Strahan'
     SpdxLicenseId: Apache-2.0
@@ -35,7 +35,7 @@ Resources:
       Handler: "com.amazonaws.athena.udf.textanalytics.TextAnalyticsUDFHandler"
       CodeUri: "./target/textanalyticsudfs-1.0.jar"
       Description: "This connector enables Amazon Athena to leverage Amazon Comprehend and Amazon Translate text analytics services via UDFs made available via Lambda."
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Policies:


### PR DESCRIPTION

*Description of changes:*

Updated Lambda runtime from java8 to java8.al2. The java8 runtime has been deprecated as per [lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html )

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
